### PR TITLE
Setup fastapi websocket and chat endpoint tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,4 +19,13 @@ dev = [
     "clai>=0.4.9",
     "pydantic-to-typescript>=2.0.0",
     "modal>=1.1.0",
+    "pytest>=8.3.3",
+    "pytest-asyncio>=0.25.0",
+    "anyio>=4.4.0",
+    "websockets>=12.0",
 ]
+
+[tool.pytest.ini_options]
+addopts = "-q"
+testpaths = ["tests"]
+asyncio_mode = "auto"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,110 @@
+import asyncio
+from collections.abc import AsyncGenerator
+from typing import Any, Dict
+
+import os
+import sys
+from pathlib import Path
+import types
+
+import pytest
+from fastapi.testclient import TestClient
+
+# Ensure project root is on sys.path so `import main` works
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+
+# Pre-inject a minimal stub for frank.agents before importing main to avoid model provider init
+async def _preimport_stub_stream_agent_response(*args: Any, **kwargs: Any):
+    # simple async generator that yields two chunks and calls on_done if provided
+    on_done = kwargs.get("on_done")
+    yield "Hello"
+    yield " world"
+    if on_done is not None:
+        await on_done(types.SimpleNamespace(prompt="hi", model="stub-model", result=None), types.SimpleNamespace(new_messages=lambda: []))
+
+_fake_agents_mod = types.ModuleType("frank.agents")
+setattr(_fake_agents_mod, "stream_agent_response", _preimport_stub_stream_agent_response)
+sys.modules.setdefault("frank.agents", _fake_agents_mod)
+
+from main import app as fastapi_app  # noqa: E402
+from frank.schemas import AgentQuery  # noqa: E402
+
+# --- Fake Redis (async) ---
+
+class FakeRedis:
+    def __init__(self):
+        self._store: Dict[str, str] = {}
+
+    async def get(self, key: str) -> str | None:
+        return self._store.get(key)
+
+    async def setex(self, key: str, ttl_seconds: int, value: str) -> None:  # noqa: ARG002
+        self._store[key] = value
+
+
+@pytest.fixture(autouse=True)
+def _mock_redis(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = FakeRedis()
+
+    def _get_redis() -> FakeRedis:  # type: ignore[override]
+        return fake
+
+    import frank.core.redis as redis_module
+    import frank.ws as ws_module
+
+    # Clear cache on original function if present, then patch in both modules
+    try:
+        redis_module.get_redis.cache_clear()  # type: ignore[attr-defined]
+    except Exception:
+        pass
+
+    monkeypatch.setattr(redis_module, "get_redis", _get_redis, raising=True)
+    monkeypatch.setattr(ws_module, "get_redis", _get_redis, raising=True)
+
+
+# --- Stub agent streaming ---
+
+class _FakeResult:
+    def new_messages(self) -> list[Any]:  # minimal to satisfy handler
+        return []
+
+
+async def _stub_stream_agent_response(
+    prompt: str,
+    model: str = "stub-model",
+    history: list[Any] | None = None,
+    on_done: Any | None = None,
+) -> AsyncGenerator[str, None]:
+    del history
+    # Yield a couple of chunks to simulate streaming
+    yield "Hello"
+    yield " world"
+    if on_done is not None:
+        await on_done(AgentQuery(prompt=prompt, model=model, result=None), _FakeResult())
+
+
+@pytest.fixture(autouse=True)
+def _mock_agent_stream(monkeypatch: pytest.MonkeyPatch) -> None:
+    import frank.agents as agents_module
+    import frank.ws as ws_module
+
+    async def _gen(*args: Any, **kwargs: Any):  # wrapper to return async generator
+        async for chunk in _stub_stream_agent_response(*args, **kwargs):
+            yield chunk
+
+    # Patch both the source module and the place where it was imported
+    monkeypatch.setattr(agents_module, "stream_agent_response", _gen, raising=True)
+    monkeypatch.setattr(ws_module, "stream_agent_response", _gen, raising=True)
+
+
+@pytest.fixture()
+def app():
+    return fastapi_app
+
+
+@pytest.fixture()
+def client(app) -> TestClient:  # type: ignore[override]
+    return TestClient(app)

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,0 +1,13 @@
+from fastapi.testclient import TestClient
+
+
+def test_healthz(client: TestClient):
+    resp = client.get("/api/healthz")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+
+
+def test_get_chat_not_found(client: TestClient):
+    resp = client.get("/api/chats/does-not-exist")
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "Chat not found"

--- a/tests/test_ws.py
+++ b/tests/test_ws.py
@@ -1,0 +1,45 @@
+import json
+from fastapi.testclient import TestClient
+
+
+def test_websocket_basic_flow_and_fetch(client: TestClient):
+    with client.websocket_connect("/ws/chat") as ws:
+        # Start a new chat
+        ws.send_text(
+            json.dumps({
+                "type": "new_chat",
+                "message": "hi",
+                "model": "stub-model",
+            })
+        )
+        ack = ws.receive_json()
+        assert ack["type"] == "new_chat_ack"
+        chat_id = ack["chatId"]
+        assert isinstance(chat_id, str) and chat_id
+
+        # Initialize with the returned chat id (should echo initialize and then stream)
+        ws.send_text(json.dumps({"type": "initialize", "chatId": chat_id}))
+
+        init_resp = ws.receive_json()
+        assert init_resp["type"] == "initialize"
+        assert init_resp.get("chatId") == chat_id or init_resp.get("chatId") is None
+
+        # Receive streamed chunks
+        chunk1 = ws.receive_json()
+        assert chunk1["type"] == "reply" and chunk1["done"] is False
+        assert chunk1["text"] == "Hello"
+
+        chunk2 = ws.receive_json()
+        assert chunk2["type"] == "reply" and chunk2["done"] is False
+        assert chunk2["text"] == " world"
+
+        done_msg = ws.receive_json()
+        assert done_msg["type"] == "reply" and done_msg["done"] is True
+
+    # After WS completes, the chat should be persisted and fetchable
+    resp = client.get(f"/api/chats/{chat_id}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["id"] == chat_id
+    assert body["pending"] is False
+    assert body["curQuery"] is not None

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
 
 [[package]]
@@ -342,9 +342,13 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "anyio" },
     { name = "clai" },
     { name = "modal" },
     { name = "pydantic-to-typescript" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "websockets" },
 ]
 
 [package.metadata]
@@ -360,9 +364,13 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "anyio", specifier = ">=4.4.0" },
     { name = "clai", specifier = ">=0.4.9" },
     { name = "modal", specifier = ">=1.1.0" },
     { name = "pydantic-to-typescript", specifier = ">=2.0.0" },
+    { name = "pytest", specifier = ">=8.3.3" },
+    { name = "pytest-asyncio", specifier = ">=0.25.0" },
+    { name = "websockets", specifier = ">=12.0" },
 ]
 
 [[package]]
@@ -639,6 +647,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641, upload-time = "2025-04-27T15:29:01.736Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/b0/36bd937216ec521246249be3bf9855081de4c5e06a0c9b4219dbeda50373/importlib_metadata-8.7.0-py3-none-any.whl", hash = "sha256:e5dd1551894c77868a30651cef00984d50e1002d06942a7101d34870c5f02afd", size = 27656, upload-time = "2025-04-27T15:29:00.214Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
 ]
 
 [[package]]
@@ -1040,6 +1057,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "prompt-toolkit"
 version = "3.0.51"
 source = { registry = "https://pypi.org/simple" }
@@ -1313,6 +1339,34 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/ba/45911d754e8eba3d5a841a5ce61a65a685ff1798421ac054f85aa8747dfb/pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c", size = 1517714, upload-time = "2025-06-18T05:48:06.109Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/16/c8a903f4c4dffe7a12843191437d7cd8e32751d5de349d45d3fe69544e87/pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7", size = 365474, upload-time = "2025-06-18T05:48:03.955Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4e/51/f8794af39eeb870e87a8c8068642fc07bce0c854d6865d7dd0f2a9d338c2/pytest_asyncio-1.1.0.tar.gz", hash = "sha256:796aa822981e01b68c12e4827b8697108f7205020f24b5793b3c41555dab68ea", size = 46652, upload-time = "2025-07-16T04:29:26.393Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/9d/bf86eddabf8c6c9cb1ea9a869d6873b46f105a5d292d3a6f7071f5b07935/pytest_asyncio-1.1.0-py3-none-any.whl", hash = "sha256:5fe2d69607b0bd75c656d1211f969cadba035030156745ee09e7d71740e58ecf", size = 15157, upload-time = "2025-07-16T04:29:24.929Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Set up a basic pytest suite for the FastAPI server to test HTTP and WebSocket endpoints and provide common fixtures.

---
<a href="https://cursor.com/background-agent?bcId=bc-982842c4-1c62-4e77-a8f3-8518b4d68ae9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-982842c4-1c62-4e77-a8f3-8518b4d68ae9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

