### PR TITLE
Fix settings panel layout and dev server startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,11 @@ devc:
 	cd client && npm run dev
 
 devall:
+	@echo "Shutting down existing dev servers..."
+	@-kill -9 $$(lsof -ti:8000) 2>/dev/null; exit 0
+	@-kill -9 $$(lsof -ti:5173) 2>/dev/null; exit 0
+	@-pkill -f "honcho start" 2>/dev/null; exit 0
+	@echo "Starting dev servers..."
 	uv run honcho start -f Procfile.dev
 
 clai:

--- a/client/src/components/Settings.tsx
+++ b/client/src/components/Settings.tsx
@@ -3,15 +3,13 @@ import { useStore } from '@/store';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import {
-  Drawer,
-  DrawerContent,
-  DrawerHeader,
-  DrawerTitle,
-  DrawerTrigger,
-  DrawerClose,
-  DrawerFooter,
-  DrawerDescription,
-} from '@/components/ui/drawer';
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+  SheetDescription,
+} from '@/components/ui/sheet';
 import {
   Select,
   SelectContent,
@@ -24,13 +22,12 @@ export default function SettingsDrawer() {
   const { model, models, setModel, themeMode, themeLabel, setThemeMode } = useStore();
 
   return (
-    <Drawer
-      direction="right"
+    <Sheet
       onOpenChange={(open) => {
         if (open) (document.activeElement as HTMLElement | null)?.blur();
       }}
     >
-      <DrawerTrigger asChild>
+      <SheetTrigger asChild>
         <Button
           variant="ghost"
           size="icon"
@@ -41,13 +38,13 @@ export default function SettingsDrawer() {
         >
           <Settings className={cn('h-6 w-6')} />
         </Button>
-      </DrawerTrigger>
-      <DrawerContent>
-        <DrawerDescription className={cn('sr-only')}>Settings drawer</DrawerDescription>
-        <DrawerHeader>
-          <DrawerTitle>Settings</DrawerTitle>
-        </DrawerHeader>
-        <div className={cn('p-4 pt-2 flex flex-col gap-4')}>
+      </SheetTrigger>
+      <SheetContent>
+        <SheetDescription className={cn('sr-only')}>Settings panel</SheetDescription>
+        <SheetHeader>
+          <SheetTitle>Settings</SheetTitle>
+        </SheetHeader>
+        <div className={cn('mt-6 flex flex-col gap-4')}>
           <div className={cn('flex items-center gap-2')}>
             <span className={cn('text-sm text-muted-foreground w-20 shrink-0')}>Theme:</span>
             <Select value={themeMode} onValueChange={setThemeMode}>
@@ -78,12 +75,7 @@ export default function SettingsDrawer() {
             </Select>
           </div>
         </div>
-        <DrawerFooter>
-          <DrawerClose asChild>
-            <Button variant="outline">Close</Button>
-          </DrawerClose>
-        </DrawerFooter>
-      </DrawerContent>
-    </Drawer>
+      </SheetContent>
+    </Sheet>
   );
 }

--- a/client/src/components/ui/sheet.tsx
+++ b/client/src/components/ui/sheet.tsx
@@ -1,0 +1,138 @@
+import * as React from "react"
+import * as SheetPrimitive from "@radix-ui/react-dialog"
+import { cva, type VariantProps } from "class-variance-authority"
+import { X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Sheet = SheetPrimitive.Root
+
+const SheetTrigger = SheetPrimitive.Trigger
+
+const SheetClose = SheetPrimitive.Close
+
+const SheetPortal = SheetPrimitive.Portal
+
+const SheetOverlay = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+    ref={ref}
+  />
+))
+SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
+
+const sheetVariants = cva(
+  "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out",
+  {
+    variants: {
+      side: {
+        top: "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+        bottom:
+          "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+        left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+        right:
+          "inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+      },
+    },
+    defaultVariants: {
+      side: "right",
+    },
+  }
+)
+
+interface SheetContentProps
+  extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
+    VariantProps<typeof sheetVariants> {}
+
+const SheetContent = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Content>,
+  SheetContentProps
+>(({ side = "right", className, children, ...props }, ref) => (
+  <SheetPortal>
+    <SheetOverlay />
+    <SheetPrimitive.Content
+      ref={ref}
+      className={cn(sheetVariants({ side }), className)}
+      {...props}
+    >
+      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </SheetPrimitive.Close>
+      {children}
+    </SheetPrimitive.Content>
+  </SheetPortal>
+))
+SheetContent.displayName = SheetPrimitive.Content.displayName
+
+const SheetHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-2 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+SheetHeader.displayName = "SheetHeader"
+
+const SheetFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+SheetFooter.displayName = "SheetFooter"
+
+const SheetTitle = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold text-foreground", className)}
+    {...props}
+  />
+))
+SheetTitle.displayName = SheetPrimitive.Title.displayName
+
+const SheetDescription = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+SheetDescription.displayName = SheetPrimitive.Description.displayName
+
+export {
+  Sheet,
+  SheetPortal,
+  SheetOverlay,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+}


### PR DESCRIPTION
##[37m [39;49;00m[31mSummary[39;49;00m[37m[39;49;00m
[37m[39;49;00m
-[37m [39;49;00m[31mReplace[39;49;00m[37m [39;49;00m[31mDrawer[39;49;00m[37m [39;49;00m[31mwith[39;49;00m[37m [39;49;00m[31mSheet[39;49;00m[37m [39;49;00m[31mcomponent[39;49;00m[37m [39;49;00m[34mfor[39;49;00m[37m [39;49;00m[31msettings[39;49;00m[37m [39;49;00m[31mpanel[39;49;00m[37m [39;49;00m[31mto[39;49;00m[37m [39;49;00m[31mproperly[39;49;00m[37m [39;49;00m[31mdisplay[39;49;00m[37m [39;49;00m[31mon[39;49;00m[37m [39;49;00m[31mthe[39;49;00m[37m [39;49;00m[31mright[39;49;00m[37m [39;49;00m[31mside[39;49;00m[37m[39;49;00m
-[37m [39;49;00m[31mAdd[39;49;00m[37m [39;49;00m[31mautomatic[39;49;00m[37m [39;49;00m[31mcleanup[39;49;00m[37m [39;49;00m[31mof[39;49;00m[37m [39;49;00m[31mhanging[39;49;00m[37m [39;49;00m[31mdev[39;49;00m[37m [39;49;00m[31mservers[39;49;00m[37m [39;49;00m[31min[39;49;00m[37m [39;49;00m[31mmake[39;49;00m[37m [39;49;00m[31mdevall[39;49;00m[37m [39;49;00m[31mtarget[39;49;00m[37m[39;49;00m
[37m[39;49;00m
[31mThe[39;49;00m[37m [39;49;00m[31msettings[39;49;00m[37m [39;49;00m[31mpanel[39;49;00m[37m [39;49;00m[31mnow[39;49;00m[37m [39;49;00m[31muses[39;49;00m[37m [39;49;00m[31mshadcn[39;49;00m[04m[91m's Sheet component instead of Drawer, which is the proper component for side panels and works without hacky CSS overrides. The make devall target now automatically kills any existing processes on ports 8000 and 5173 before starting, preventing hanging servers.[39;49;00m[37m[39;49;00m